### PR TITLE
pasta, opt-einsum: Avoid fetching sources twice

### DIFF
--- a/recipes-python/opt-einsum/opt-einsum_3.3.0.bb
+++ b/recipes-python/opt-einsum/opt-einsum_3.3.0.bb
@@ -17,9 +17,13 @@ PR = "1"
 S  = "${WORKDIR}/opt_einsum-${PV}"
 
 GH_URI  = "https://github.com/dgasmith/opt_einsum/archive/refs/tags/v${PV}.tar.gz"
-SRC_URI = "${GH_URI} \
-           ${GH_URI};unpack=false;downloadfilename=${PN}_${PV}.orig.tar.gz \
+SRC_URI = "${GH_URI};unpack=false;downloadfilename=${PN}_${PV}.orig.tar.gz \
            file://opt_einsum-${PV}/debian"
 SRC_URI[sha256sum] = "a748fdbccfce5af420ea56f8e2c51a6dc9e8774afd9179cb8addfab159b7b33c"
 
 PROVIDES += "python3-${PN}"
+
+python do_unpack_append() {
+    from subprocess import check_call
+    check_call(["tar", "xzf", d.getVar('PN') + "_" + d.getVar('PV') + ".orig.tar.gz"])
+}

--- a/recipes-python/pasta/pasta_0.2.0.bb
+++ b/recipes-python/pasta/pasta_0.2.0.bb
@@ -16,11 +16,15 @@ DEB_BUILD_OPTIONS += "nocheck"
 PR = "2"
 
 GH_URI  = "https://github.com/google/${PN}/archive/refs/tags/v${PV}.tar.gz"
-SRC_URI = "${GH_URI} \
-           ${GH_URI};unpack=false;downloadfilename=${PN}_${PV}.orig.tar.gz \
+SRC_URI = "${GH_URI};unpack=false;downloadfilename=${PN}_${PV}.orig.tar.gz \
            file://${PN}-${PV}/debian                                       "
 SRC_URI[sha256sum] = "b9e3bcf5ab79986e245c8a2f3a872d14c610ce66904c4f16818342ce81cf97d2"
 
 PROVIDES += "python3-${PN}"
 
 do_dpkg_build[cleandirs] += "${S}/google_pasta.egg-info"
+
+python do_unpack_append() {
+    from subprocess import check_call
+    check_call(["tar", "xzf", d.getVar('PN') + "_" + d.getVar('PV') + ".orig.tar.gz"])
+}


### PR DESCRIPTION
We want the orig tarball to stay in WORKDIR even after unpacking. Rather
than fetching and caching it twice, also using a too generic name for
one instance, skip the auto-unpack and perform that as extra step in
do_unpack explicitly.
