### PR TITLE
fix: copy local_toolchain to sources to have it in orig.tar.gz

### DIFF
--- a/recipes-devtools/bazel-toolchains/bazel-toolchains.inc
+++ b/recipes-devtools/bazel-toolchains/bazel-toolchains.inc
@@ -12,14 +12,14 @@
 # This file provides local bazel toolchains to cross-compile
 # with system / host compilers
 
-inherit dpkg
+inherit dpkg-bazel
 
 FILESEXTRAPATHS_prepend := "${FILE_DIRNAME}/files"
 SRC_URI += "file://local_toolchains"
 
+do_link_bazel_toolchains[cleandirs] += "${S}/local_toolchains"
 do_link_bazel_toolchains() {
-    rm -f ${S}/local_toolchains
-    ln -s ${PP}/local_toolchains ${S}
+    cp -r ${WORKDIR}/local_toolchains ${S}/
 }
 
-addtask link_bazel_toolchains after do_install_builddeps before do_dpkg_build
+addtask link_bazel_toolchains after do_install_builddeps before do_fetch_bazel_deps


### PR DESCRIPTION
This patch copies the local_toolchain folder into the source folder
instead of symlinking. This is required to have the content in
the orig.tar.gz archive, instead of a dangling symlink.

Signed-off-by: Felix Moessbauer <felix.moessbauer@siemens.com>