### PR TITLE
recipes-kernel/gasket-module: install udev rules

### DIFF
--- a/recipes-kernel/gasket-module/files/gasket-module.udev
+++ b/recipes-kernel/gasket-module/files/gasket-module.udev
@@ -1,0 +1,1 @@
+SUBSYSTEM=="apex", MODE="0660", GROUP="apex"

--- a/recipes-kernel/gasket-module/gasket-module_1.1.5.bb
+++ b/recipes-kernel/gasket-module/gasket-module_1.1.5.bb
@@ -10,7 +10,15 @@
 
 require recipes-kernel/linux-module/module.inc
 
-SRC_URI += "git://github.com/google/gasket-driver.git;protocol=https;branch=main"
+SRC_URI += "git://github.com/google/gasket-driver.git;protocol=https;branch=main \
+            file://gasket-module.udev"
 SRCREV = "f047773516dd65435becf09d8d03e5ef2a9f4165"
 
 S = "${WORKDIR}/git/src"
+
+do_prepare_build_append() {
+    install -m 644 ${WORKDIR}/gasket-module.udev ${S}/debian/${PN}.udev
+    printf "\n" >> ${S}/debian/rules
+    printf "override_dh_installudev:\n" >> ${S}/debian/rules
+    printf "\tdh_installudev --priority=65\n" >> ${S}/debian/rules
+}


### PR DESCRIPTION
Make /dev/apex* devices owned by the "apex" group using udev
rules as suggested in the "Get started with the M.2 or Mini PCIe
Accelerator" guide.

Signed-off-by: Cedric Hombourger <cedric.hombourger@siemens.com>