### PR TITLE
feat: update gasket kernel module and dkms package

### DIFF
--- a/recipes-kernel/gasket-dkms/gasket-dkms_1.0.bb
+++ b/recipes-kernel/gasket-dkms/gasket-dkms_1.0.bb
@@ -10,8 +10,8 @@
 # Files below ./files are licensed under the GPL-2.0-or-later license
 
 inherit dpkg
+require recipes-kernel/gasket-module/gasket-module-version.inc
 
-SRC_URI = "git://github.com/google/gasket-driver.git;protocol=https;branch=main;destsuffix=${P}"
-SRC_URI += "file://0001-add-section-and-priority-information.patch"
-# no releases yet
-SRCREV = "f047773516dd65435becf09d8d03e5ef2a9f4165"
+PR = "18"
+SRC_URI = "git://github.com/google/gasket-driver.git;protocol=https;branch=main;destsuffix=${P} \
+           file://0001-add-section-and-priority-information.patch"

--- a/recipes-kernel/gasket-module/gasket-module-version.inc
+++ b/recipes-kernel/gasket-module/gasket-module-version.inc
@@ -6,11 +6,7 @@
 #
 # This file is subject to the terms and conditions of the MIT License.
 # See COPYING.MIT file in the top-level directory.
-#
 
-require recipes-kernel/linux-module/module.inc
-
-SRC_URI += "git://github.com/google/gasket-driver.git;protocol=https;branch=main"
-SRCREV = "f047773516dd65435becf09d8d03e5ef2a9f4165"
-
-S = "${WORKDIR}/git/src"
+# no release tags yet.
+# This refers to debian version 1.0-18, module version 1.1.4
+SRCREV = "97aeba584efd18983850c36dcf7384b0185284b3"

--- a/recipes-kernel/gasket-module/gasket-module_1.1.4.bb
+++ b/recipes-kernel/gasket-module/gasket-module_1.1.4.bb
@@ -1,0 +1,16 @@
+#
+# Copyright (c) Siemens AG, 2022
+#
+# Authors:
+#  Felix Moessbauer <felix.moessbauer@siemens.com>
+#
+# This file is subject to the terms and conditions of the MIT License.
+# See COPYING.MIT file in the top-level directory.
+#
+
+require recipes-kernel/linux-module/module.inc
+require recipes-kernel/gasket-module/gasket-module-version.inc
+
+SRC_URI = "git://github.com/google/gasket-driver.git;protocol=https;branch=main"
+
+S = "${WORKDIR}/git/src"


### PR DESCRIPTION
This patch updates the gasket kernel module and makes the versioning more precise:
The upsteam module has a debian version and a module version that are not identical.
This is now reflected in the bitbake recipe versions.

Signed-off-by: Felix Moessbauer <felix.moessbauer@siemens.com>