### PR TITLE
fix(gasket-module): append upstream src to SRC_URI instead of overwriting

### DIFF
--- a/.github/workflows/free-disk-space/action.yml
+++ b/.github/workflows/free-disk-space/action.yml
@@ -1,0 +1,23 @@
+#
+# Copyright (c) Siemens AG, 2022
+#
+# Authors:
+#  Quirin Gylstorff <quirin.gylstorff@siemens.com>
+#
+# This file is subject to the terms and conditions of the MIT License.
+# See COPYING.MIT file in the top-level directory.
+#
+
+name: 'Free Disk Space'
+description: 'Remove content of the provided image to free disk space for the build'
+runs:
+  using: "composite"
+  steps:
+      - name:  Free disk space
+        run: |
+          sudo apt-get purge 'dotnet*' google-chrome-stable 'temurin*' google-cloud-sdk hhvm azure-cli 'mongodb*' powershell firefox chromium 'llvm*' 'libllvm*' 'adoptopenjdk*' 'mysql*' libgl1-mesa-dri apache2 'mono*'
+          sudo rm -rf /usr/local/* /opt/hostedtoolcache /opt/pipx* /opt/az
+        shell: bash
+      - name: Show disk space usage
+        run:  df -h
+        shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Free Disk Space
+        uses: ./.github/workflows/free-disk-space
       - name: Build image
         run: ./kas-container build kas/meta-coral.yml
       - name: Collect artifacts
@@ -58,6 +60,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Free Disk Space
+        uses: ./.github/workflows/free-disk-space
       - name: Build image
         run: ./kas-container build kas/meta-coral.yml:kas/opt/aarch64-target.yml
       - name: Collect artifacts

--- a/kas/meta-coral.yml
+++ b/kas/meta-coral.yml
@@ -23,21 +23,12 @@ repos:
 build_system: isar
 machine: qemuamd64
 distro: debian-bullseye
-target:
-  - libedgetpu
-  - astunparse
-  - keras-preprocessing
-  - opt-einsum
-  - pasta
-  - python-absl
-  - python-gast
-  - bazel-bootstrap
-  - gasket-dkms
-  - tensorflow
-  - pycoral
+target: ci-meta-coral
 
 local_conf_header:
   arch: |
     DISTRO_ARCH = "amd64"
   ccache: |
     USE_CCACHE = "1"
+  kernel: |
+    KERNEL_NAME = "${DISTRO_ARCH}"

--- a/recipes-kernel/gasket-module/gasket-module_1.1.4.bb
+++ b/recipes-kernel/gasket-module/gasket-module_1.1.4.bb
@@ -14,3 +14,13 @@ require recipes-kernel/gasket-module/gasket-module-version.inc
 SRC_URI += "git://github.com/google/gasket-driver.git;protocol=https;branch=main"
 
 S = "${WORKDIR}/git/src"
+
+# At least for bullseye arm64 the kernel headers depend on cpp-10:arm64.
+# The cpp-10:arm64 package cannot be co-installed with cpp-10.
+# Without sbuilder support, we must not remove packages from the build tree,
+# hence have to compile in the target buildchroot
+def is_distro_kernel(d):
+    kernel_name = d.getVar('KERNEL_NAME', True)
+    return kernel_name in d.getVar('DISTRO_KERNELS', True)
+
+ISAR_CROSS_COMPILE = "${@'0' if is_distro_kernel(d) else '1'}"

--- a/recipes-kernel/gasket-module/gasket-module_1.1.4.bb
+++ b/recipes-kernel/gasket-module/gasket-module_1.1.4.bb
@@ -11,6 +11,6 @@
 require recipes-kernel/linux-module/module.inc
 require recipes-kernel/gasket-module/gasket-module-version.inc
 
-SRC_URI = "git://github.com/google/gasket-driver.git;protocol=https;branch=main"
+SRC_URI += "git://github.com/google/gasket-driver.git;protocol=https;branch=main"
 
 S = "${WORKDIR}/git/src"

--- a/recipes-test/ci-meta-coral/ci-meta-coral.bb
+++ b/recipes-test/ci-meta-coral/ci-meta-coral.bb
@@ -1,0 +1,28 @@
+#
+# Copyright (c) Siemens AG, 2022
+#
+# Authors:
+#  Felix Moessbauer <felix.moessbauer@siemens.com>
+#
+# This file is subject to the terms and conditions of the MIT License.
+# See COPYING.MIT file in the top-level directory.
+#
+
+# This is a meta recipe to test the building of all packages
+
+inherit dpkg-raw
+
+DEPENDS = "                      \
+    libedgetpu                   \
+    astunparse                   \
+    keras-preprocessing          \
+    opt-einsum                   \
+    pasta                        \
+    python-absl                  \
+    python-gast                  \
+    bazel-bootstrap              \
+    gasket-dkms                  \
+    gasket-module-${KERNEL_NAME} \
+    tensorflow                   \
+    pycoral                      \
+"


### PR DESCRIPTION
Fixes the regression introduced in 8bc2be36d6 on clean builds.
The upstream src has to be appended to SRC_URI to not overwrite
the referenced local files.

Signed-off-by: Felix Moessbauer <felix.moessbauer@siemens.com>