### PR TITLE
refactor: use templates instead of shell env in libedgetpu

### DIFF
--- a/recipes-framework/libedgetpu/files/libedgetpu-release-grouper/debian/rules.tmpl
+++ b/recipes-framework/libedgetpu/files/libedgetpu-release-grouper/debian/rules.tmpl
@@ -5,6 +5,8 @@ include /usr/share/dpkg/buildtools.mk
 
 # Uncomment this to turn on verbose mode.
 # export DH_VERBOSE=1
+export TFROOT = ${TENSORFLOW_SRC_ROOT}
+
 LIBEDGETPU_BIN ?= out
 FILENAME := libedgetpu.so.1.0
 SONAME := libedgetpu.so.1

--- a/recipes-framework/libedgetpu/libedgetpu_16.0.bb
+++ b/recipes-framework/libedgetpu/libedgetpu_16.0.bb
@@ -15,15 +15,15 @@ REL = "grouper"
 PR  = "1"
 S   = "${WORKDIR}/${PN}-release-${REL}"
 
+TEMPLATE_FILES += "libedgetpu-release-grouper/debian/rules.tmpl"
+TEMPLATE_VARS += "TENSORFLOW_SRC_ROOT"
+TENSORFLOW_SRC_ROOT="tensorflow"
+
 SRC_URI = "https://github.com/google-coral/${PN}/archive/refs/tags/release-${REL}.tar.gz;name=lib \
-           git://github.com/tensorflow/tensorflow.git;branch=master;protocol=https;name=tf;rev=${TF_SRCREV};nobranch=1;destsuffix=${S}/tensorflow \
+           git://github.com/tensorflow/tensorflow.git;branch=master;protocol=https;name=tf;rev=${TF_SRCREV};nobranch=1;destsuffix=${S}/${TENSORFLOW_SRC_ROOT} \
            file://${PN}-release-${REL}/debian \
            file://0001-make-compilers-configurable-to-support-cross-compili.patch \
            file://0002-fix-add-missing-include-for-gcc-11.patch"
 SRC_URI[lib.sha256sum] = "86a6e654e093c204b4fb579a60773bfa080f095c9cbb3a2c114ca4a13e0b15eb"
 
 PROVIDES += "libedgetpu1-std libedgetpu1-max libedgetpu-dev"
-
-dpkg_runbuild_prepend(){
-    export TFROOT="tensorflow"
-}


### PR DESCRIPTION
This patch replaces the export of the TFROOT path by a
template. By that, we improve the compatibility with future
ISAR revisions.

Signed-off-by: Felix Moessbauer <felix.moessbauer@siemens.com>