### PR TITLE
fix: adapt bazel-bootstrap to recent upstream changes

### DIFF
--- a/recipes-devtools/bazel-bootstrap/bazel-bootstrap_4.1.0+ds_1.bb
+++ b/recipes-devtools/bazel-bootstrap/bazel-bootstrap_4.1.0+ds_1.bb
@@ -10,6 +10,9 @@
 
 inherit dpkg-gbp
 
+GBP_DEPENDS_remove = "pristine-tar"
+GBP_EXTRA_OPTIONS = "--git-no-pristine-tar --git-upstream-branch=jc-4.1.0 --git-upstream-tree=BRANCH"
+
 # build this package for the buildchroot-host
 PACKAGE_ARCH = "${HOST_ARCH}"
 # we do not really cross-compile, but have to work in the buildchroot-host


### PR DESCRIPTION
This patch adapts the bazel-bootstrap packaging to upstream packaging changes.
By pinning it to the branch, we force gbp to use exactly the version we also used previously for building.
By that, no semantic, dependency or code changes of bazel-bootstrap itself are expected.

closes: #27 

Signed-off-by: Felix Moessbauer <felix.moessbauer@siemens.com>