### PR TITLE
Collection of small modernizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+isar
 out
 build*
 build.sh

--- a/kas/meta-coral.yml
+++ b/kas/meta-coral.yml
@@ -21,6 +21,7 @@ repos:
     refspec: a4de91e7debb49b47e502b70527a6a91fb8cb9fc
     layers:
       meta:
+      meta-isar:
 
   meta-coral:
 
@@ -30,7 +31,5 @@ distro: debian-bullseye
 target: ci-meta-coral
 
 local_conf_header:
-  arch: |
-    DISTRO_ARCH = "amd64"
   kernel: |
     KERNEL_NAME = "${DISTRO_ARCH}"

--- a/recipes-devtools/bazel-bootstrap/bazel-bootstrap_4.2.2+ds-1.bb
+++ b/recipes-devtools/bazel-bootstrap/bazel-bootstrap_4.2.2+ds-1.bb
@@ -11,7 +11,7 @@
 inherit dpkg-gbp
 
 GBP_DEPENDS_remove = "pristine-tar"
-GBP_EXTRA_OPTIONS = "--git-no-pristine-tar --git-upstream-branch=jc-4.1.0 --git-upstream-tree=BRANCH"
+GBP_EXTRA_OPTIONS = "--git-no-pristine-tar --git-upstream-branch=master"
 
 # build this package for the buildchroot-host
 PACKAGE_ARCH = "${HOST_ARCH}"
@@ -19,5 +19,5 @@ PACKAGE_ARCH = "${HOST_ARCH}"
 ISAR_CROSS_COMPILE = "1"
 
 # note, this is not the official debian bazel-bootstrap (it still only provides 3.5.x)
-SRC_URI = "git://git@salsa.debian.org/bazel-team/bazel-bootstrap.git;protocol=https;branch=jc-4.1.0"
-SRCREV = "abc7db5dae3293a1905418bcbc733ed1effcd14d"
+SRC_URI = "git://git@salsa.debian.org/bazel-team/bazel-bootstrap.git;protocol=https;branch=master"
+SRCREV = "300661f84ab8682f09896ffab2651a0d3740711f"


### PR DESCRIPTION
This MR is a collection of small modernizations to mainly improve the build itself. For details, please have a look at the individual commit messages. One major aspect is that we bring bazel-bootstrap back to the new debian release. By that, we do no longer depend on an unstable branch.